### PR TITLE
Grunt dist: also copy (top-level) img or images folder

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -165,7 +165,9 @@ module.exports = function(grunt) {
                         src: [
                             './index.html',
                             './**/*.html',
-                            './**/*.json'
+                            './**/*.json',
+                            './img/**/*.*',
+                            './images/**/*.*'
                         ]
                     },
                     {


### PR DESCRIPTION
The `grunt dist` task did not copy the `img` or `images` folder to the dist folder. I suppose that's usually desirable. I don't know if it would be better to copy *all* occurrences of these folders, instead of just the top-level one.